### PR TITLE
Enforce using C++ 11 in odom2tf

### DIFF
--- a/tools/odom2tf/CMakeLists.txt
+++ b/tools/odom2tf/CMakeLists.txt
@@ -1,5 +1,18 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(odom2tf)
+
+## Enforce that we use C++11
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-std=c++11" COMPILER_SUPPORTS_CXX11)
+check_cxx_compiler_flag("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+  add_definitions(-std=c++11)
+elseif(COMPILER_SUPPORTS_CXX0X)
+  add_definitions(-std=c++0x)
+else()
+  message(STATUS "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
     roscpp
     nav_msgs


### PR DESCRIPTION
`odom2tf` uses c++ 11 features, but so far we did not make sure that the code is actually compiled with `-std=c++11`.